### PR TITLE
Change IRC info on community page from freenode to libera

### DIFF
--- a/_posts/2021-06-02-IRC-Server-Change.md
+++ b/_posts/2021-06-02-IRC-Server-Change.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title: 'LinuxCNC IRC is moving to Libera.chat'
+---
+Following the example of many prominent projects including
+[Centos](https://blog.centos.org/2021/05/centos-irc-channels-moving-to-irc-libera-chat/),
+[Fedora](https://fedoramagazine.org/irc-announcement-fedora-moving-to-libera-chat/),
+[FreeBSD](https://wiki.freebsd.org/IRC/Official-FreeBSD-IRC-channels-now-on-Libera-Chat),
+[Gentoo](https://www.gentoo.org/news/2021/05/23/Moving-to-Libera.html),
+[Wikipedia](https://meta.wikimedia.org/wiki/IRC/Migrating_to_Libera_Chat), and
+[Ubuntu](https://www.omgubuntu.co.uk/2021/05/ubuntu-irc-moves-to-libera-chat),
+the LinuxCNC project is shifting its primary real-time chat presence to the new
+[Libera.chat](https://libera.chat) IRC service.  See the [community
+page](https://www.linuxcnc.org/community/) for information on how to connect,
+including directly in your web browser.
+
+Most IRC clients support connecting to multiple networks at the same time, so
+if you still want to participate on channels on Freenode (or have direct
+messages with people on Freenode) this option is available to you as well.
+
+We thank Freenode's largely volunteer staff for providing a space to organize
+and discuss LinuxCNC for many years, and we thank the Libera.chat staff
+for providing a new space for the years to come.
+
+Because of [reported retaliation for mentioning the libera.chat alternative
+on freenode](https://www.theregister.com/2021/05/26/freenode_irc_takeover/),
+the channel topics on the Freenode channels will not be updated to directly
+refer to libera.chat by name.

--- a/community/index.md
+++ b/community/index.md
@@ -21,10 +21,10 @@ CNC topics.
   at SourceForge.
 
 * The other preferred way to contact us is on
-  [IRC](http://webchat.freenode.net/?channels=%23linuxcnc),
-  (#linuxcnc on irc.freenode.net).  More information about connecting
-  with your own client can be found on FreeNode's [how to use the
-  network](http://freenode.net/using_the_network.shtml) page.
+  [IRC](https://web.libera.chat/),
+  (#linuxcnc on irc.libera.chat).  More information about connecting
+  with your own client can be found on Libera's [how to use the
+  network](https://libera.chat/guides/connect) page.
   
 * A community member has registered a Matrix room, [#LCNC:matrix.org (link joins via riot.im)](https://riot.im/app/#/room/#LCNC:matrix.org).
 
@@ -51,6 +51,6 @@ LinuxCNC](/docs/html/code/contributing-to-linuxcnc.html).
   at SourceForge.
 
 * The other preferred way to contact us is on
-  [IRC](http://webchat.freenode.net/?channels=%23linuxcnc-devel),
-  (#linuxcnc-devel on irc.freenode.net).
+  [IRC](https://web.libera.chat/),
+  (#linuxcnc-devel on irc.libera.chat).
 

--- a/community/index.md
+++ b/community/index.md
@@ -9,8 +9,8 @@ date: 2006-02-27 14:42:54.000000000 -07:00
 
 ## Users
 
-Use these methods for help setting up and using LinuxCNC, and for general
-CNC topics.
+*Use these methods for help setting up and using LinuxCNC, and for general
+CNC topics.*
 
 * The LinuxCNC [Forum](https://forum.linuxcnc.org/) is a user maintained
   place to discuss LinuxCNC.
@@ -20,11 +20,10 @@ CNC topics.
   and [archived](https://sourceforge.net/p/emc/mailman/emc-users/)
   at SourceForge.
 
-* The other preferred way to contact us is on
-  [IRC](https://web.libera.chat/),
-  (#linuxcnc on irc.libera.chat).  More information about connecting
-  with your own client can be found on Libera's [how to use the
-  network](https://libera.chat/guides/connect) page.
+* Our primary real-time chat is in the *#linuxcnc* channel on [irc.libera.chat](https://libera.chat).
+  You can use [web chat](https://web.libera.chat/) or
+  [connect with your own client](https://libera.chat/guides/connect).
+  The chat is [logged](http://tom-itx.no-ip.biz:81/~tom-itx/irc/libera/logs/%23linuxcnc/index.html) by community member Tom L., and historical logs from freenode are [also available](http://tom-itx.no-ip.biz:81/~tom-itx/irc/logs/%23linuxcnc/index.html).
   
 * A community member has registered a Matrix room, [#LCNC:matrix.org (link joins via riot.im)](https://riot.im/app/#/room/#LCNC:matrix.org).
 
@@ -39,10 +38,10 @@ CNC topics.
 
 ## Developers
 
-Use these methods to contribute to the development of LinuxCNC, including
-documentation, translation, new drivers and components.
+*Use these methods to contribute to the development of LinuxCNC, including
+documentation, translation, new drivers and components.*
 
-* [Contributing to
+* Learn more about [Contributing to
 LinuxCNC](/docs/html/code/contributing-to-linuxcnc.html).
 
 * The primary means of communication is the [developers' mailing
@@ -50,7 +49,7 @@ LinuxCNC](/docs/html/code/contributing-to-linuxcnc.html).
   and [archived](https://sourceforge.net/p/emc/mailman/emc-developers/)
   at SourceForge.
 
-* The other preferred way to contact us is on
-  [IRC](https://web.libera.chat/),
-  (#linuxcnc-devel on irc.libera.chat).
-
+* Our primary real-time chat is in the *#linuxcnc-devel* channel on [irc.libera.chat](https://libera.chat).
+  You can use [web chat](https://web.libera.chat/) or
+  [connect with your own client](https://libera.chat/guides/connect).
+  The chat is [logged](http://tom-itx.no-ip.biz:81/~tom-itx/irc/libera/logs/%23linuxcnc-devel/index.html) by community member Tom L., and historical logs from freenode are [also available](http://tom-itx.no-ip.biz:81/~tom-itx/irc/logs/%23linuxcnc-devel/index.html).


### PR DESCRIPTION
There are already around 50 users in the libera channel.
Buildbot and logs need to be configured to the new server.