### PR TITLE
Eliminated syntax errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This is the Jekyll source for the www.linuxcnc.org website.
 
-It works well with Jekyll 2.2.0 (in Debian Jessie).
+It works well with Jekyll 2.2.0 (in Debian Jessie) or 3.9.0 (in Debian bookworm).
 
 1.  Edit the files with any editor you like.
 2.  Test with "jekyll serve".

--- a/index.md
+++ b/index.md
@@ -52,7 +52,7 @@ printers, laser cutters, plasma cutters, robot arms, hexapods, and more.
         limit or offset a list. There is no fix upstream for it due to backwards
         compatibility concerns. https://github.com/Shopify/liquid/pull/456
     {% endcomment %}
-    {% assign showcase = site.showcase | sort 'date' | reverse %}
+    {% assign showcase = site.showcase | sort: 'date' | reverse %}
   {% for post in showcase reversed limit:1 %}
     <span class="post-date">{{ post.date | date: "%b %-d, %Y" }}</span>
     <h2>

--- a/showcase.xml
+++ b/showcase.xml
@@ -16,7 +16,7 @@ layout: null
         limit or offset a list.  They haven't applied a fix for it due to backwards
         compatibility concerns.  https://github.com/Shopify/liquid/pull/456
     {% endcomment %}
-    {% assign showcase = site.showcase | sort 'date' | reverse %}
+    {% assign showcase = site.showcase | sort: 'date' | reverse %}
     {% for post in showcase limit:10 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>

--- a/showcase/index.md
+++ b/showcase/index.md
@@ -27,7 +27,7 @@ our users to do.
         limit or offset a list.  They haven't applied a fix for it due to backwards
         compatibility concerns.  https://github.com/Shopify/liquid/pull/456
     {% endcomment %}
-    {% assign showcase = site.showcase | sort 'date' | reverse %}
+    {% assign showcase = site.showcase | sort: 'date' | reverse %}
     {% for post in showcase %}
       <li>
         <span class="post-date">{{ post.date | date: "%b %-d, %Y" }}</span>


### PR DESCRIPTION
I just tested the web pages on Debian unstable and they worked as they are. However, I got <del>this error</del> these _warnings_ and eventually found that these disappear when I add colons. Even though I feel fairly confident about this patch, I cannot claim that I would truly have understood what I am doing.
```
Liquid Warning: Liquid syntax error (line 24): Expected end_of_string but found string in "{{site.showcase | sort 'date' | reverse }}" in showcase/index.md
Liquid Warning: Liquid syntax error (line 50): Expected end_of_string but found string in "{{site.showcase | sort 'date' | reverse }}" in index.md
Liquid Warning: Liquid syntax error (line 16): Expected end_of_string but found string in "{{site.showcase | sort 'date' | reverse }}" in showcase.xml
``