### PR TITLE
Initial attempt towards a schematic table

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,88 +5,90 @@ title: LinuxCNC
 
 {% if site.data.version %}<!-- site built from {{ site.data.version }} -->{% endif %}
 
-<div id=intro>
 <div><img src="images/screen_thumb.png" border="0" alt=" " width="350"
 height="250" style="float:right" /></div>
 
 LinuxCNC controls CNC machines. It can drive milling machines, lathes, 3D
 printers, laser cutters, plasma cutters, robot arms, hexapods, and more.
 
-<li> Runs under Linux (optionally with realtime extensions).
+* Runs under Linux (optionally with realtime extensions).
 
-<li> Simple installation on Debian and Ubuntu, or via our Live/Install
+* Simple installation on Debian and Ubuntu, or via our Live/Install
   DVD/USB images.
 
-<li> Accepts G-code input, drives CNC machines in response.
+* Accepts G-code input, drives CNC machines in response.
 
-<li> Active user community.
+* Active user community.
 
-<li> Several different GUIs available.
+* Several different GUIs available.
 
-<li> Compatible with many popular machine control hardware interfaces.
+* Compatible with many popular machine control hardware interfaces.
 
-<li> Supports rigid tapping, cutter compensation, and many other advanced
+* Supports rigid tapping, cutter compensation, and many other advanced
   control features.
 
-<li> Full source code available under the terms of the GNU <a href="http://www.gnu.org/licenses/old-licenses/gpl-2.0.html">GPLv2 (General Public License version 2)</a>
-</ul>
-</div>
+* Full source code available under the terms of the GNU <a href="http://www.gnu.org/licenses/old-licenses/gpl-2.0.html">GPLv2 (General Public License version 2)</a>
 
-
-<div id=schema>
 <table width="100%">
+<colgroup>
+<col width="45%" />
+<col width="10%" />
+<col width="45%" />
+</colgroup>
+<tbody>
 <tr>
 <td valign=top>
 <h2>CAD</h2>
-The Computer-Aided Design (CAD) is typically the initiation of a project that involves LinuxCNC. It provides a static picture of what shall be produced and describes this in a 2D or 3D model. A series of Open Source tools are available to craft a design, like
-<ul>
-<li>FreeCAD
-<li>Blender
-<li>Inkscape
-<li>...
-</ul>
 
-but Linux is also compatible with all commercial software solutions like
-<ul>
-<li>SolidWorkds
-<li>Fusion360
-<li>...
-</ul>
+The Computer-Aided Design (CAD) is typically the initiation of a project that involves LinuxCNC. It provides a static picture of what shall be produced and describes this in a 2D or 3D model. A series of Open Source tools are available to craft a design, like<br>
+
+* FreeCAD<br>
+* Blender<br>
+* Inkscape<br>
+* ...<br>
+
+but Linux is also compatible with all commercial software solutions like<br>
+
+* SolidWorkds<br>
+* Fusion360<br>
+* ...<br>
+
 LinuxCNC does not know how its input is generated. Also, it does not do any planning. If your machine needs to react to changes in the environment while it is running, then you want to look into robotics libraries to substitute what CAD and CAM are providing. But you can still use LinuxCNC to control the machine and read out data from it - all in real time.
 </td>
-<td valign=center> -> </td>
-<td><h2 valign=top>CAM</h2>
-Computer-Aided Manufactoring (CAM) reads the design and knows hot to get the work done. This involves
-<ul>
-<li>what tool to use for what metal with what speed and what depth
-<li>along what coordinates
-</ul>
+<td valign=center align=center> -> </td>
+<td valign=top>
+<h2>CAM</h2>
+
+Computer-Aided Manufactoring (CAM) reads the design and knows hot to get the work done. This involves<br>
+
+* what tool to use for what metal with what speed and what depth<br>
+* along what coordinates<br>
+
 Much of that process is automated. But CAM has no cameras, i.e. it does not know what dimensions that block of material has that is in the machine. The output of CAM is a file that LinuxCNC can understand, typically this is G-Code. Some CAD tools also help with CAM, in the Open Source world this typically is
-<ul>
-<li>FreeCAD.
-</ul>
+
+* FreeCAD.
+
 but any tool providing G-Code will be fine. It should be noted that CAM already needs to know about the functionality of the machine. The tools available for one, but also the number of axes that are available for the processing.
 </td>
 </tr>
-<tr><td colspan=2></td><td align=center>|<br>v</td></tr>
+<tr><td colspan=2></td><td align=center valign=center>|<br>v</td></tr>
 <tr>
-<td colspan=3><h2>LinuxCNC</h2>
+<td colspan=3>
+<h2>LinuxCNC</h2>
 LinuxCNC comes to play once all instructions what traces to follow with what tool at what speed are known and now LinuxCNC becomes the operator of the machine to actually perform the work.
-This involves prepatory processes like
-<ul>
-<li>the homing of the machine to specific coordinates
-<li>calibration to matche distances to the number of steps on a motor or the pulse width for a servo
-<li>error correction to compensate e.g. for a backlash and/or latencies in the communication
-</ul>
+This involves prepatory processes like<br>
 
-<br>
+* the homing of the machine to specific coordinates<br>
+* calibration to matche distances to the number of steps on a motor or the pulse width for a servo<br>
+* error correction to compensate e.g. for a backlash and/or latencies in the communication<br>
+
 Together with its GUI, LinuxCNC nicely substitutes the control units one finds attached to the side of CNC lathes or mills, with extra flexibility for customisations, you can log in remotely, and script it.
 </td>
 </tr>
 <tr>
-<td align=center>^<br>|</td>
+<td align=center><br>^<br>|</td>
 <td></td>
-<td align=center>^<br>|</td>
+<td align=center><br>^<br>|</td>
 </tr>
 <tr>
 <td valign=top><h2>Control panel</h2>
@@ -100,9 +102,8 @@ There is no conceptional constraint on what machines can be controlled with Linu
 Communication with the machine is likely bidirectional. Emergency stop, end switches - a series of sensors are typically built into machines that can be read-out and presented back to LinuxCNC, which reacts to it and updates the control panel, too.
 </td>
 </tr>
+</tbody>
 </table>
-
-</div>
 
 <div id="site-news">
   <h1>News</h1>

--- a/index.md
+++ b/index.md
@@ -5,30 +5,104 @@ title: LinuxCNC
 
 {% if site.data.version %}<!-- site built from {{ site.data.version }} -->{% endif %}
 
+<div id=intro>
 <div><img src="images/screen_thumb.png" border="0" alt=" " width="350"
 height="250" style="float:right" /></div>
 
 LinuxCNC controls CNC machines. It can drive milling machines, lathes, 3D
 printers, laser cutters, plasma cutters, robot arms, hexapods, and more.
 
-* Runs under Linux (optionally with realtime extensions).
+<li> Runs under Linux (optionally with realtime extensions).
 
-* Simple installation on Debian and Ubuntu, or via our Live/Install
+<li> Simple installation on Debian and Ubuntu, or via our Live/Install
   DVD/USB images.
 
-* Accepts G-code input, drives CNC machines in response.
+<li> Accepts G-code input, drives CNC machines in response.
 
-* Active user community.
+<li> Active user community.
 
-* Several different GUIs available.
+<li> Several different GUIs available.
 
-* Compatible with many popular machine control hardware interfaces.
+<li> Compatible with many popular machine control hardware interfaces.
 
-* Supports rigid tapping, cutter compensation, and many other advanced
+<li> Supports rigid tapping, cutter compensation, and many other advanced
   control features.
 
-* Full source code available under the terms of the [GNU GPLv2
-  (General Public License version 2)][GPLv2].
+<li> Full source code available under the terms of the GNU <a href="http://www.gnu.org/licenses/old-licenses/gpl-2.0.html">GPLv2 (General Public License version 2)</a>
+</ul>
+</div>
+
+
+<div id=schema>
+<table width="100%">
+<tr>
+<td valign=top>
+<h2>CAD</h2>
+The Computer-Aided Design (CAD) is typically the initiation of a project that involves LinuxCNC. It provides a static picture of what shall be produced and describes this in a 2D or 3D model. A series of Open Source tools are available to craft a design, like
+<ul>
+<li>FreeCAD
+<li>Blender
+<li>Inkscape
+<li>...
+</ul>
+
+but Linux is also compatible with all commercial software solutions like
+<ul>
+<li>SolidWorkds
+<li>Fusion360
+<li>...
+</ul>
+LinuxCNC does not know how its input is generated. Also, it does not do any planning. If your machine needs to react to changes in the environment while it is running, then you want to look into robotics libraries to substitute what CAD and CAM are providing. But you can still use LinuxCNC to control the machine and read out data from it - all in real time.
+</td>
+<td valign=center> -> </td>
+<td><h2 valign=top>CAM</h2>
+Computer-Aided Manufactoring (CAM) reads the design and knows hot to get the work done. This involves
+<ul>
+<li>what tool to use for what metal with what speed and what depth
+<li>along what coordinates
+</ul>
+Much of that process is automated. But CAM has no cameras, i.e. it does not know what dimensions that block of material has that is in the machine. The output of CAM is a file that LinuxCNC can understand, typically this is G-Code. Some CAD tools also help with CAM, in the Open Source world this typically is
+<ul>
+<li>FreeCAD.
+</ul>
+but any tool providing G-Code will be fine. It should be noted that CAM already needs to know about the functionality of the machine. The tools available for one, but also the number of axes that are available for the processing.
+</td>
+</tr>
+<tr><td colspan=2></td><td align=center>|<br>v</td></tr>
+<tr>
+<td colspan=3><h2>LinuxCNC</h2>
+LinuxCNC comes to play once all instructions what traces to follow with what tool at what speed are known and now LinuxCNC becomes the operator of the machine to actually perform the work.
+This involves prepatory processes like
+<ul>
+<li>the homing of the machine to specific coordinates
+<li>calibration to matche distances to the number of steps on a motor or the pulse width for a servo
+<li>error correction to compensate e.g. for a backlash and/or latencies in the communication
+</ul>
+
+<br>
+Together with its GUI, LinuxCNC nicely substitutes the control units one finds attached to the side of CNC lathes or mills, with extra flexibility for customisations, you can log in remotely, and script it.
+</td>
+</tr>
+<tr>
+<td align=center>^<br>|</td>
+<td></td>
+<td align=center>^<br>|</td>
+</tr>
+<tr>
+<td valign=top><h2>Control panel</h2>
+A monitor attached to the computer running LinuxCNC may well substitute the CNC control panel that originally shipped with a machine, like a SINUMERIK, Heinzmann, Heidenhain, Rexroth - you name them. That said, older CNC panels have their own historic value we encourage their maintenance if that is an option for a retrofit.
+The LinuxCNC GUI can be modified to present custom data on the screen, e.g. from additional sensors. And scripts performing the execution can be made dependent on these data.
+</td>
+<td></td>
+<td valign=top><h2>Machine</h2>
+There is no conceptional constraint on what machines can be controlled with LinuxCNC. With its real-time functionality, LinuxCNC reacts as fast as computers can react and can be programmed to anticipate the position of the machine in the future to coordinate all axes in a timely manner for best precision.
+<br>
+Communication with the machine is likely bidirectional. Emergency stop, end switches - a series of sensors are typically built into machines that can be read-out and presented back to LinuxCNC, which reacts to it and updates the control panel, too.
+</td>
+</tr>
+</table>
+
+</div>
 
 <div id="site-news">
   <h1>News</h1>
@@ -75,5 +149,3 @@ printers, laser cutters, plasma cutters, robot arms, hexapods, and more.
   </ul>
   <p class="rss-subscribe">subscribe to Showcases <a href="{{ "/showcase.xml" | prepend: site.baseurl }}">via RSS</a></p>
 </div>
-
-[GPLv2]: http://www.gnu.org/licenses/old-licenses/gpl-2.0.html


### PR DESCRIPTION
First attempt address https://github.com/LinuxCNC/wlo/issues/19

There are two challenges.
a) To decide what a noob-intro to LinuxCNC could look like
b) Integrate this somehow into the home page in a way that does not look too bad
For now, I hope to just focus on a), i.e. find the right things to talk about and then find the right words that neither offend the individual hearing those words the first time nor any of the LinuxCNC devs. This PR introduces an HTML table that connects CAD, CAM, LinuxCNC, Machine, Control Panel with descriptions. What is missing is the notion of the HAL but that should then be a second schema.

I hope to also come up with many hyperlinks to the documentation/the wiki for more details and also to other sites, like FreeCAD.

Wrt b), I like the news section to somehow either appear next to this description or right below it. Below the news I then think I would want to mix showcases of retrofits and new builds with a notion of costs associated to get going. Something smallish that would qualify as a present for a kid (and myself) would be great.