### PR TITLE
remove empty lines in 2.9.x release notes

### DIFF
--- a/_posts/2023-11-05-LinuxCNC-2.9.md
+++ b/_posts/2023-11-05-LinuxCNC-2.9.md
@@ -69,140 +69,140 @@ Abbreviated Changelog:
 
 This release contains contributions from the following authors: 
 
-ALatSMT
-Alec Ari
-Alexey Starikovskiy
-Alex Lait
-alkabal
-Allan Nordhøy
-Ambr Enzs
-Andreas Christoffersen
-André Litfin
-Andrew Downing
-andrewheeler82
-Andrew Kyrychenko
-Andrii Podanenko
-andy pugh
-Arvid Brodin
-Asle Næss
-Benson Muite
-Billy Soto
-Bob Bond
-Bruno Lualdi
-Bryce Johnson
-ButterflyOfFire
-cascade256
-Chad A. Woitas
-Chadly
-chris
-Chris Morley
-Chris Nisbet
-Chris Radek
-cnc
-Colten Edwards
-Csa söl
-Curtis Dutton
-d2inventory
-Damian Wrobel
-damiodj
-Daniel Rogge
-david
-Davide Cerati
-ddlu
-ddotldot
-DerAndere
-Dewey Garrett
-D.L
-Dmitry S. aka D.L
-D. Mueller
-Egor Komogortsev
-ekam230
-Ernesto Lo Valvo
-freddii
-Greg Carl
-Gunnar Wolf
-Hakan Kaner
-Hannah Lau
-Hans Unzner
-Håvard F. Aasen
-Håvard Flaget Aasen
-Horváth Csaba
-htasta
-Ihor Oliinyk
-issyvarsano
-Jan Mrázek
-JanneK
-Jan Roters
-jb0
-Jeff Epler
-Jérémie Tarot
-Jerry Trantow
-J.M.Garcia
-John Morris
-John Thornton
-Jose Manuel Garcia de Torres
-joseph calderon
-Juraj Adamkovic
-Kale Yuzik
-Klaus Naumann
-Leonardo Daniel Marsaglia
-luz paz
-Mark
-Markus
-Mark van Doesburg
-Martin Kaplan
-Mateusz Konieczny
-Matthew Johnston
-Matthias
-Michael Langer
-Michael Stellmacher
-mk00002
-Moses McKnight
-mwork
-NhanPham
-nicokid
-Nicola Quargentan
-nicolas
-Nikita Shubin
-noel
-Norbert Schechner
-oMtQB4
-pc179
-Peter C Wallace
-Peter Müller
-Petr Menšík
-Petteri Aimonen
-Petter Reinholdtsen
-Phillip A Carter
-Rainer Stelzer
-Rene Hopf
-Rob Clegg
-Robert W. Ellenberg
-Robin Szemeti
-Roguish
-root
-rpm-build
-russellgower
-samcoinc
-Sascha Ittner
-Sebastian Kuzminsky
-simaoamorim
-snowgoer540
-spike
-Steffen Möller
-sundtek
-Sync
-Tim Blume
-Tinic Uro
-Toni Laiho
-Trần Ngọc Quân
-TRothfelder
-Ulices
-whatawhiz
-yohsuke
-zz912
-Александр Макарчук
-Дмитрий
-トトも
-大宝剑
+ALatSMT, 
+Alec Ari, 
+Alexey Starikovskiy, 
+Alex Lait, 
+alkabal, 
+Allan Nordhøy, 
+Ambr Enzs, 
+Andreas Christoffersen, 
+André Litfin, 
+Andrew Downing, 
+andrewheeler82, 
+Andrew Kyrychenko, 
+Andrii Podanenko, 
+andy pugh, 
+Arvid Brodin, 
+Asle Næss, 
+Benson Muite, 
+Billy Soto, 
+Bob Bond, 
+Bruno Lualdi, 
+Bryce Johnson, 
+ButterflyOfFire, 
+cascade256, 
+Chad A. Woitas, 
+Chadly, 
+chris, 
+Chris Morley, 
+Chris Nisbet, 
+Chris Radek, 
+cnc, 
+Colten Edwards, 
+Csa söl, 
+Curtis Dutton, 
+d2inventory, 
+Damian Wrobel, 
+damiodj, 
+Daniel Rogge, 
+david, 
+Davide Cerati, 
+ddlu, 
+ddotldot, 
+DerAndere, 
+Dewey Garrett, 
+D.L, 
+Dmitry S. aka D.L, 
+D. Mueller, 
+Egor Komogortsev, 
+ekam230, 
+Ernesto Lo Valvo, 
+freddii, 
+Greg Carl, 
+Gunnar Wolf, 
+Hakan Kaner, 
+Hannah Lau, 
+Hans Unzner, 
+Håvard F. Aasen, 
+Håvard Flaget Aasen, 
+Horváth Csaba, 
+htasta, 
+Ihor Oliinyk, 
+issyvarsano, 
+Jan Mrázek, 
+JanneK, 
+Jan Roters, 
+jb0, 
+Jeff Epler, 
+Jérémie Tarot, 
+Jerry Trantow, 
+J.M.Garcia, 
+John Morris, 
+John Thornton, 
+Jose Manuel Garcia de Torres, 
+joseph calderon, 
+Juraj Adamkovic, 
+Kale Yuzik, 
+Klaus Naumann, 
+Leonardo Daniel Marsaglia, 
+luz paz, 
+Mark, 
+Markus, 
+Mark van Doesburg, 
+Martin Kaplan, 
+Mateusz Konieczny, 
+Matthew Johnston, 
+Matthias, 
+Michael Langer, 
+Michael Stellmacher, 
+mk00002, 
+Moses McKnight, 
+mwork, 
+NhanPham, 
+nicokid, 
+Nicola Quargentan, 
+nicolas, 
+Nikita Shubin, 
+noel, 
+Norbert Schechner, 
+oMtQB4, 
+pc179, 
+Peter C Wallace, 
+Peter Müller, 
+Petr Menšík, 
+Petteri Aimonen, 
+Petter Reinholdtsen, 
+Phillip A Carter, 
+Rainer Stelzer, 
+Rene Hopf, 
+Rob Clegg, 
+Robert W. Ellenberg, 
+Robin Szemeti, 
+Roguish, 
+root, 
+rpm-build, 
+russellgower, 
+samcoinc, 
+Sascha Ittner, 
+Sebastian Kuzminsky, 
+simaoamorim, 
+snowgoer540, 
+spike, 
+Steffen Möller, 
+sundtek, 
+Sync, 
+Tim Blume, 
+Tinic Uro, 
+Toni Laiho, 
+Trần Ngọc Quân, 
+TRothfelder, 
+Ulices, 
+whatawhiz, 
+yohsuke, 
+zz912, 
+Александр Макарчук, 
+Дмитрий, 
+トトも, 
+大宝剑, 
 陈浩

--- a/_posts/2023-12-25-LinuxCNC-2.9.2.md
+++ b/_posts/2023-12-25-LinuxCNC-2.9.2.md
@@ -13,13 +13,9 @@ should now be working again.
 Packages have been prepared for:
 
 Buster - uspace - amd64 (PC) armhf (Pi) arm64 (Pi with 64-bit kernels)
-
 Buster - RTAI - amd64
-
 Bullseye - uspace - ams64 (only)
-
 Bookworm - uspace - amd64, arm64
-
 Bookworm - RTAI - amd64
 
 For existing users of 2.9.1 on the above platforms this should be
@@ -31,37 +27,21 @@ me know. (all but the amd64 uspace builds have to be manually created)
 Contributors to this release are:
 
 Alec Ari
-
 andypugh
-
 c-morley
-
 dps.lwk
-
 Greg Carl
-
 Hans Unzner
-
 Håvard F. Aasen
-
 Moses McKnight
-
 Norbert Schechner
-
 Peter Wallace
-
 Petter Reinholdtsen
-
 Phillip Carter
-
 Rene Hopf
-
 Sebastian Kuzminsky
-
 Sigma1912
-
 Steffen Moeller
-
 
 Full changelog:
 

--- a/_posts/2024-07-12-LinuxCNC-2.9.3.md
+++ b/_posts/2024-07-12-LinuxCNC-2.9.3.md
@@ -19,13 +19,9 @@ This is a bugfix release. Highlights include:
 Packages have been prepared for:
 
 Buster - uspace - amd64 (PC) armhf (Pi) arm64 (Pi with 64-bit kernels)
-
 Buster - RTAI - amd64
-
 Bullseye - uspace - ams64 (only)
-
 Bookworm - uspace - amd64, arm64
-
 Bookworm - RTAI - amd64
 
 For existing users of 2.9.2 on the above platforms this should be
@@ -37,39 +33,22 @@ me know. (all but the amd64 uspace builds have to be manually created)
 Contributors to this release are:
 
 andypugh
-
 Chad Woitas
-
 CMorley
-
 David Mueller
-
 fsabbatini89
-
 Greg Carl
-
 Hans Unzner
-
 Håvard F. Aasen
-
 John Lama
-
 John Thornton
-
 Mark
-
 Moses McKnight
-
 Peter Wallace
-
 Petter Reinholdtsen
-
 Phillip Carter
-
 Sigma1912
-
 Steffen Möller
-
 zz912
 
 Full changelog:


### PR DESCRIPTION
In my opinion the empty lines make the release notes longer than necessary.
Also add commas to the authors list for the 2.9.1 release notes.